### PR TITLE
Bump to Dawarich 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dawarich Home Assistant App
 
-**Current Dawarich version: 1.6.1** ([release notes](https://github.com/Freika/dawarich/releases/tag/1.6.1))
+**Current Dawarich version: 1.7.0** ([release notes](https://github.com/Freika/dawarich/releases/tag/1.7.0))
 
 [![HA App][ha-app-badge]][ha-app-link]
 

--- a/dawarich/CHANGELOG.md
+++ b/dawarich/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.7.0-1
+
+- Upgrade base image to Dawarich 1.7.0 ([release notes](https://github.com/Freika/dawarich/releases/tag/1.7.0))
+- Map v2 Timeline is now a first-class feature — a full Google Timeline replacement
+- Configurable GPS noise filtering in Map v2 → Settings (accuracy threshold 50–1000 m, was hardcoded to 100 m); can be disabled entirely for trains and other weak-signal sources
+- Monthly digest emails on the 2nd of each month (opt out at Settings → Email Preferences); year-end digest is now a separate toggle
+- Year-end digest email rewritten with ASCII charts so it renders cleanly in Gmail/Outlook
+- Visible, selectable family invitation URL on the family page — useful for self-hosted instances without SMTP
+- Many bug fixes: visit names no longer overwritten by location names, Map v2 replay slider respects configured timezone, Stats charts no longer stuck on "Loading…", date-navigation buttons honour selected interval, country canonicalization on Stats page
+
 ## 1.6.1-1
 
 - Upgrade base image to Dawarich 1.6.1

--- a/dawarich/build.yaml
+++ b/dawarich/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: freikin/dawarich:1.6.1
-  amd64: freikin/dawarich:1.6.1
+  aarch64: freikin/dawarich:1.7.0
+  amd64: freikin/dawarich:1.7.0
 args:
   S6_OVERLAY_VERSION: "3.2.2.0"
   BASHIO_VERSION: "0.16.2"

--- a/dawarich/config.yaml
+++ b/dawarich/config.yaml
@@ -1,5 +1,5 @@
 name: Dawarich
-version: "1.6.1-1"
+version: "1.7.0-1"
 slug: dawarich
 description: Self-hosted location tracking — Google Timeline alternative
 url: https://github.com/thomdev-j/homeassistant-addon-dawarich


### PR DESCRIPTION
## Summary

- Bump base image from `freikin/dawarich:1.6.1` → `1.7.0` (`build.yaml`)
- Bump addon version `1.6.1-1` → `1.7.0-1` (`config.yaml`)
- Update README current-version banner
- Add `1.7.0-1` entry to `dawarich/CHANGELOG.md` summarizing user-facing 1.7.0 changes

## ⚠️ Do not merge yet

`freikin/dawarich:1.7.0` is **not yet published** to Docker Hub as of 2026-04-27. The GitHub release was tagged 2026-04-26, but the image hasn't been pushed. Docker Hub state:

- `latest` → 1.6.1 (2026-04-01)
- Most recent tag: `1.6.2-rc.1` (2026-04-21)
- `1.7.0` → 404

Building this addon now would fail. Wait until Docker Hub has the image, then merge.

To verify the image is available before merging:
```
curl -sf "https://hub.docker.com/v2/repositories/freikin/dawarich/tags/1.7.0" | jq '.images[].architecture'
```
should return `amd64` and `arm64`.

The repo's `check-dawarich-release.yml` workflow (runs Mondays) also performs this check automatically.

## What's in 1.7.0

The "Timeline Release". Highlights:
- Map v2 Timeline is now a full Google Timeline replacement
- Configurable GPS noise filtering (50–1000 m, or off — was hardcoded 100 m)
- Monthly digest emails (year-end digest split into a separate toggle)
- Bug fixes: visit-name preservation, replay-slider timezone, Stats charts loading, date-nav prev/next interval handling, country canonicalization

No new env vars are required — S3 storage support is opt-in and we don't expose it in the addon config (data stays in `/data/dawarich/storage`).

## Test plan

- [ ] Confirm `freikin/dawarich:1.7.0` exists on Docker Hub for `amd64` + `arm64`
- [ ] Pull the updated addon on the Pi 5 and verify it builds
- [ ] Start the addon, confirm migrations run cleanly from the existing 1.6.1 database
- [ ] Open the UI via ingress, sign in, confirm Map v2 + Timeline render
- [ ] Confirm HA tracker still pushes points (look for `HA Tracker: pushed` in logs)
- [ ] Test backup/restore cycle works with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)