### PR TITLE
Bump to Dawarich 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dawarich Home Assistant App
 
-**Current Dawarich version: 1.6.1** ([release notes](https://github.com/Freika/dawarich/releases/tag/1.6.1))
+**Current Dawarich version: 1.7.1** ([release notes](https://github.com/Freika/dawarich/releases/tag/1.7.1))
 
 [![HA App][ha-app-badge]][ha-app-link]
 

--- a/dawarich/CHANGELOG.md
+++ b/dawarich/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.1-1
+
+- Upgrade base image to Dawarich 1.7.1 — see upstream [1.7.0](https://github.com/Freika/dawarich/releases/tag/1.7.0) and [1.7.1](https://github.com/Freika/dawarich/releases/tag/1.7.1) release notes for user-facing changes
+
 ## 1.6.1-1
 
 - Upgrade base image to Dawarich 1.6.1

--- a/dawarich/build.yaml
+++ b/dawarich/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: freikin/dawarich:1.6.1
-  amd64: freikin/dawarich:1.6.1
+  aarch64: freikin/dawarich:1.7.1
+  amd64: freikin/dawarich:1.7.1
 args:
   S6_OVERLAY_VERSION: "3.2.2.0"
   BASHIO_VERSION: "0.16.2"

--- a/dawarich/config.yaml
+++ b/dawarich/config.yaml
@@ -1,5 +1,5 @@
 name: Dawarich
-version: "1.6.1-1"
+version: "1.7.1-1"
 slug: dawarich
 description: Self-hosted location tracking — Google Timeline alternative
 url: https://github.com/thomdev-j/homeassistant-addon-dawarich


### PR DESCRIPTION
## Summary

- Bump base image: `freikin/dawarich:1.6.1` → `1.7.1` (`build.yaml`)
- Bump addon version: `1.6.1-1` → `1.7.1-1` (`config.yaml`)
- Update README current-version banner
- Add `1.7.1-1` entry to `dawarich/CHANGELOG.md` (linking to upstream release notes for user-facing changes)

Supersedes #2, which targeted 1.7.0 but couldn't merge because the upstream Docker image hadn't shipped yet. 1.7.1 was released the next day (2026-04-28); its image landed on Docker Hub for `amd64` + `arm64`, so this PR is ready to merge.

## Why no addon-side changes

- 1.7.0's S3 storage support is opt-in (defaults to local) — no env-var change needed
- 1.7.1's mobile auth + Traccar ingest endpoints work out of the box
- 1.7.1 makes 2FA env vars optional (build fix), no addon impact

## Test plan

- [x] Pull updated addon on the Pi 5 and verify it builds
- [x] Start the addon, confirm migrations run cleanly from the existing 1.6.1 database
- [x] Open UI via ingress, sign in, confirm Map v2 + Timeline render
- [x] Confirm HA tracker still pushes points (look for `HA Tracker: pushed` in logs)
- [x] Test backup/restore cycle works with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)