### PR TITLE
Restore the database from HA backups instead of silently dropping it

### DIFF
--- a/dawarich/CHANGELOG.md
+++ b/dawarich/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.10.1-2
+
+- **Fix data loss when restoring a Home Assistant backup.** Backups exclude the raw PostgreSQL files (`backup_exclude: postgres/**`) and ship a `pg_dumpall` dump instead, but nothing ever imported that dump again — a restored app came up with a freshly initialized, empty database and every recorded location was silently gone, even though the dump sat unused in `/data/dawarich/backup.sql`. The app now imports it on the first start after a restore and logs how many users and points came back. The import only runs into a database nobody has used yet (a freshly initialized cluster, or one where no user ever signed in, nothing was imported and fewer than 1000 points exist), so it can never overwrite data on an app that is already in use
+- Fix a partial `pg_dumpall` being packed into a backup as if it were complete: the dump is written to a temporary file and only moved into place once it succeeds. A failed dump now fails the backup instead of quietly shipping an unusable one
+- Report a failing admin-user creation instead of swallowing it. `admin_password` shorter than Dawarich's 12-character minimum made `User.create!` raise "Password is too short"; the error scrolled past in the log and the app started with **no account to log in with**, which looks exactly like a forgotten password. The password length is now checked at startup and a failure is reported explicitly
+- Set `DOMAIN` (from the first entry of `application_hosts`) so Dawarich can build absolute URLs in Devise mails. Without it, an account that got locked after 10 failed logins hit `Missing host to link to!` while rendering the unlock mail and the login page returned HTTP 500
+
 ## 1.10.1-1
 
 - Upgrade base image to Dawarich 1.10.1 — see upstream release notes for [1.8.0](https://github.com/Freika/dawarich/releases/tag/1.8.0), [1.8.1](https://github.com/Freika/dawarich/releases/tag/1.8.1), [1.9.0](https://github.com/Freika/dawarich/releases/tag/1.9.0), [1.9.1](https://github.com/Freika/dawarich/releases/tag/1.9.1), [1.9.2](https://github.com/Freika/dawarich/releases/tag/1.9.2), [1.10.0](https://github.com/Freika/dawarich/releases/tag/1.10.0), and [1.10.1](https://github.com/Freika/dawarich/releases/tag/1.10.1)

--- a/dawarich/DOCS.md
+++ b/dawarich/DOCS.md
@@ -103,7 +103,9 @@ Home Assistant backups are supported:
 - **Post-backup:** The SQL dump is cleaned up to save disk space
 - Raw PostgreSQL files (`postgres/**`) are excluded from the backup — only the SQL dump is included
 
-To restore from backup, the app will automatically detect and restore the SQL dump on startup if the PostgreSQL data directory is empty.
+To restore from backup, the app detects the SQL dump on startup and imports it. Because the raw PostgreSQL files are not part of the backup, a restore hands the app an empty data directory plus that dump, and the import is what brings your history back — watch the app log for `Database restored: … user(s), … point(s)` on the first start after a restore.
+
+To protect data you have not backed up, the import only runs into a database nobody has used yet (a fresh cluster, or one where no user has ever signed in, nothing has been imported and fewer than 1000 points exist). If you restore a backup onto an app that already holds data, the log says so and your existing data is left alone — restore into a fresh install instead.
 
 ## Network Security
 

--- a/dawarich/config.yaml
+++ b/dawarich/config.yaml
@@ -1,5 +1,5 @@
 name: Dawarich
-version: "1.10.1-1"
+version: "1.10.1-2"
 slug: dawarich
 description: Self-hosted location tracking — Google Timeline alternative
 url: https://github.com/thomdev-j/homeassistant-app-dawarich

--- a/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
+++ b/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
@@ -7,11 +7,66 @@ until pg_isready -h localhost -p 5432 -U postgres -q; do
   sleep 1
 done
 
-# Create database user and database if they don't exist
 DB_USER=$(cat /var/run/s6/container_environment/DATABASE_USERNAME)
 DB_NAME=$(cat /var/run/s6/container_environment/DATABASE_NAME)
 DB_PASS=$(cat /var/run/s6/container_environment/DATABASE_PASSWORD)
 
+# --- Restore the database from a Home Assistant backup, if one is waiting ---
+# HA backups exclude the raw PostgreSQL files (backup_exclude: postgres/** in
+# config.yaml) and ship a pg_dumpall dump instead (backup_pre.sh). Restoring an
+# app therefore hands us an empty data directory plus that dump — if nobody
+# imports it, the app comes up with an empty database and every location the
+# user ever recorded is silently gone.
+DB_DUMP=/data/dawarich/backup.sql
+RESTORE_MARKER=/data/dawarich/.db_restored
+PG_FRESH_INIT=$(cat /var/run/s6/container_environment/PG_FRESH_INIT 2>/dev/null || echo "false")
+
+if [ -s "$DB_DUMP" ]; then
+  DUMP_SUM=$(md5sum "$DB_DUMP" | cut -d' ' -f1)
+
+  # Never import into a database that is in use. A dump is only imported when the
+  # cluster was just initialized, the database does not exist yet, or nothing has
+  # happened in it: nobody ever signed in, nothing was imported and fewer than
+  # 1000 points exist (the app auto-creates its users on boot, and HA tracking can
+  # push a handful of points before we get here).
+  IN_USE=1
+  if [ "$DUMP_SUM" = "$(cat "$RESTORE_MARKER" 2>/dev/null)" ]; then
+    echo "Database dump at ${DB_DUMP} was already imported, skipping restore."
+  elif [ "$PG_FRESH_INIT" = "true" ]; then
+    IN_USE=0
+  elif ! su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -tAc \"SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'\"" | grep -q 1; then
+    IN_USE=0
+  else
+    IN_USE=$(su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -d ${DB_NAME} -tAc \"SELECT (CASE WHEN to_regclass('public.users') IS NULL THEN 0 ELSE (SELECT count(*) FROM users WHERE sign_in_count > 0) END) + (CASE WHEN to_regclass('public.imports') IS NULL THEN 0 ELSE (SELECT count(*) FROM imports) END) + (CASE WHEN to_regclass('public.points') IS NULL THEN 0 ELSE (SELECT count(*) / 1000 FROM points) END)\"" 2>/dev/null | tr -d '[:space:]')
+    [ -z "$IN_USE" ] && IN_USE=1
+  fi
+
+  if [ "$IN_USE" = "0" ]; then
+    echo "Found a database dump from a Home Assistant backup ($(du -h "$DB_DUMP" | cut -f1)), restoring it..."
+    su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -q -c \"DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE);\"" 2>&1
+    su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -q -d postgres -f ${DB_DUMP}" 2>&1
+
+    RESTORED=$(su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -d ${DB_NAME} -tAc \"SELECT CASE WHEN to_regclass('public.users') IS NULL THEN 0 ELSE (SELECT count(*) FROM users) END\"" 2>/dev/null | tr -d '[:space:]')
+    if [ -n "$RESTORED" ]; then
+      POINTS=$(su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -d ${DB_NAME} -tAc \"SELECT count(*) FROM points\"" 2>/dev/null | tr -d '[:space:]')
+      echo "Database restored: ${RESTORED} user(s), ${POINTS} point(s)."
+      # The dump carries the role with the password it had when the backup was
+      # taken; re-sync it with the currently configured one.
+      su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -q -c \"ALTER ROLE ${DB_USER} WITH LOGIN PASSWORD '${DB_PASS}';\"" 2>&1
+      printf '%s' "$DUMP_SUM" > "$RESTORE_MARKER"
+      rm -f "$DB_DUMP"
+    else
+      echo "ERROR: restoring ${DB_DUMP} did not produce a usable database. The dump has been kept."
+      echo "ERROR: the app will continue with an empty database — do not take a new backup before this is resolved,"
+      echo "ERROR: it would overwrite the dump. Check the psql errors above."
+    fi
+  elif [ "$IN_USE" != "0" ] && [ "$DUMP_SUM" != "$(cat "$RESTORE_MARKER" 2>/dev/null)" ]; then
+    echo "WARNING: found an unimported database dump at ${DB_DUMP}, but this database is already in use."
+    echo "WARNING: leaving the existing data untouched. Restore into a fresh app install to import that dump."
+  fi
+fi
+
+# Create database user and database if they don't exist
 su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -tc \"SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'\" | grep -q 1 || PATH=/usr/lib/postgresql/17/bin:\$PATH psql -c \"CREATE ROLE ${DB_USER} WITH LOGIN PASSWORD '${DB_PASS}' CREATEDB;\""
 su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -tc \"SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'\" | grep -q 1 || PATH=/usr/lib/postgresql/17/bin:\$PATH psql -c \"CREATE DATABASE ${DB_NAME} OWNER ${DB_USER};\""
 su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH psql -d ${DB_NAME} -c 'CREATE EXTENSION IF NOT EXISTS postgis;'"
@@ -48,7 +103,9 @@ fi
 ADMIN_EMAIL=$(cat /var/run/s6/container_environment/ADMIN_EMAIL 2>/dev/null || echo "")
 ADMIN_PASSWORD=$(cat /var/run/s6/container_environment/ADMIN_PASSWORD 2>/dev/null || echo "")
 if [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
-  bundle exec rails runner "
+  # A failure here leaves the app with no account to log in with, so report it
+  # instead of letting the exception scroll past as just another log line.
+  if ! bundle exec rails runner "
     user = User.find_or_create_by!(email: '${ADMIN_EMAIL}') do |u|
       u.password = '${ADMIN_PASSWORD}'
       u.password_confirmation = '${ADMIN_PASSWORD}'
@@ -60,7 +117,11 @@ if [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
     end
     File.write('/data/dawarich/api_key', user.api_key)
     puts \"API key saved to /data/dawarich/api_key\"
-  " 2>&1
+  " 2>&1; then
+    echo "ERROR: could not create or verify the admin user (${ADMIN_EMAIL}) — see the error above."
+    echo "ERROR: if it says \"Password is too short\", set an admin_password of at least 12 characters"
+    echo "ERROR: in the app configuration and restart. Without this user there is no account to log in with."
+  fi
 fi
 
 # --- Per-entity API key setup for multi-user device tracking ---

--- a/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
+++ b/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
@@ -30,9 +30,26 @@ printf '%s' "$(bashio::config 'time_zone')" > /var/run/s6/container_environment/
 printf '%s' "$(bashio::config 'application_hosts')" > /var/run/s6/container_environment/APPLICATION_HOSTS
 printf '%s' "$(bashio::config 'background_processing_concurrency')" > /var/run/s6/container_environment/BACKGROUND_PROCESSING_CONCURRENCY
 
+# DOMAIN is what Dawarich uses to build absolute URLs in mails (Devise unlock and
+# password-reset instructions). Unset, rendering those mails raises "Missing host
+# to link to!" and the request 500s — which is what a locked-out account hits on
+# its next login attempt, instead of being told the account is locked.
+PRIMARY_HOST="$(bashio::config 'application_hosts' | cut -d',' -f1 | xargs)"
+[ -z "$PRIMARY_HOST" ] && PRIMARY_HOST="homeassistant.local"
+printf '%s' "$PRIMARY_HOST" > /var/run/s6/container_environment/DOMAIN
+
 # Admin user credentials
 printf '%s' "$(bashio::config 'admin_email')" > /var/run/s6/container_environment/ADMIN_EMAIL
 printf '%s' "$(bashio::config 'admin_password')" > /var/run/s6/container_environment/ADMIN_PASSWORD
+
+# Dawarich rejects passwords shorter than 12 characters. Creating the admin user
+# would fail with "Password is too short" and leave the app with no account to
+# log in with, so warn about it here rather than at the point of failure.
+ADMIN_PW="$(bashio::config 'admin_password')"
+if [ -n "$ADMIN_PW" ] && [ ${#ADMIN_PW} -lt 12 ]; then
+  bashio::log.warning "admin_password is only ${#ADMIN_PW} characters — Dawarich requires at least 12."
+  bashio::log.warning "The admin user cannot be created until you set a longer password in the app configuration."
+fi
 
 # HA location tracker settings
 printf '%s' "$(bashio::config 'ha_tracked_entities')" > /var/run/s6/container_environment/HA_TRACKED_ENTITIES
@@ -101,8 +118,13 @@ else
 fi
 
 # --- PostgreSQL init on first run ---
+# A missing cluster means either a first install or a restored backup (HA backups
+# exclude postgres/**). svc-dawarich needs to tell those apart to decide whether
+# it may import a SQL dump, so record it here.
+printf '%s' "false" > /var/run/s6/container_environment/PG_FRESH_INIT
 if [ ! -f /data/postgres/PG_VERSION ]; then
   bashio::log.info "Initializing PostgreSQL database..."
+  printf '%s' "true" > /var/run/s6/container_environment/PG_FRESH_INIT
   chown -R postgres:postgres /data/postgres
   su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH initdb -D /data/postgres"
   # Trust auth: safe because PG binds to localhost only, port 5432 not exposed

--- a/dawarich/rootfs/usr/share/dawarich/backup_pre.sh
+++ b/dawarich/rootfs/usr/share/dawarich/backup_pre.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/with-contenv bash
 # Pre-backup: dump PostgreSQL to a SQL file so the backup captures a consistent snapshot.
-# Raw PG files are excluded via backup_exclude in config.yaml.
+# Raw PG files are excluded via backup_exclude in config.yaml, so this dump is the
+# only copy of the database inside the backup — svc-dawarich imports it again on
+# the next start after a restore.
 
 export PATH="/usr/lib/postgresql/17/bin:${PATH}"
 
+DUMP=/data/dawarich/backup.sql
+
 if pg_isready -h localhost -p 5432 -U postgres -q; then
-  su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH pg_dumpall" > /data/dawarich/backup.sql
-  echo "PostgreSQL backup completed successfully."
+  # Dump to a temporary file first: a partial dump left at the real path would be
+  # picked up by the restore as if it were a complete one.
+  if su - postgres -c "PATH=/usr/lib/postgresql/17/bin:\$PATH pg_dumpall" > "${DUMP}.tmp"; then
+    mv "${DUMP}.tmp" "${DUMP}"
+    echo "PostgreSQL backup completed successfully ($(du -h "${DUMP}" | cut -f1))."
+  else
+    rm -f "${DUMP}.tmp" "${DUMP}"
+    echo "ERROR: pg_dumpall failed — this backup will NOT contain the database."
+    exit 1
+  fi
 else
   echo "WARNING: PostgreSQL is not running, skipping database dump."
 fi


### PR DESCRIPTION
## The bug

`config.yaml` excludes the raw PostgreSQL files from Home Assistant backups (`backup_exclude: postgres/**`) and `backup_pre.sh` ships a `pg_dumpall` dump in their place. **Nothing ever imported that dump again.**

So a restore hands the app an empty `/data/postgres`, `init-dawarich.sh` initializes a fresh cluster, and the app comes up with zero history — while the dump sits unread at `/data/dawarich/backup.sql`. `DOCS.md` has been documenting the import as if it existed:

> To restore from backup, the app will automatically detect and restore the SQL dump on startup if the PostgreSQL data directory is empty.

Found the hard way on a real restore: the app came back with an empty database, one auto-created user and 4 points.

## The fix

`svc-dawarich/run` imports the dump before migrating. The safety rule is that it **only imports into a database nobody has used yet** — a freshly initialized cluster, a missing database, or one where no user has ever signed in, nothing has been imported and fewer than 1000 points exist (the app auto-creates users on boot and HA tracking can push a few points before we get there). Anything else logs a warning and leaves the data untouched. A checksum marker prevents re-imports on later boots, and the role password is re-synced with the configured one afterwards.

Exercised against stubbed `su`/`psql` across six scenarios: fresh cluster, unused-but-existing database, in-use database, already-imported marker, no dump, and a failed import.

## Three failures that made the empty database look like a forgotten password

- **`backup_pre.sh`** wrote `pg_dumpall` straight to `backup.sql`, so a dump that died halfway was packed into the backup as though it were complete. It now writes to a temporary file and only moves it into place on success, failing the backup otherwise.
- **A failing admin-user creation was swallowed.** An `admin_password` below Dawarich's 12-character minimum makes `User.create!` raise `Password is too short`; the exception scrolled past in the log and the app started with *no account to log in with*. The length is now checked at startup and the failure reported explicitly.
- **`DOMAIN` was never set**, so once an account had been locked by 10 failed attempts, rendering Devise's unlock mail raised `Missing host to link to!` and the login page returned HTTP 500 instead of saying the account was locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)