### PR TITLE
Sign people in from their Home Assistant account

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,32 @@ Check the app logs for `connected — receiving real-time state changes` to conf
 
 Duplicate locations (same lat/lon) are always skipped. Additionally, positions closer than `ha_min_distance` meters (default: 10m) to the last recorded point are filtered out — this prevents GPS drift from generating spurious data points when your phone is stationary.
 
+## Signing in automatically
+
+Home Assistant knows who is looking at the sidebar, so the app can sign that person in
+without a Dawarich password. Set `ingress_auto_login` to `on` and opening Dawarich from the
+sidebar drops you straight into your own map.
+
+It matches you to an account through the entities in `ha_tracked_entities`: Home Assistant
+knows which of its accounts is behind a person entity, and behind any `device_tracker` that
+a person lists as theirs, and this app already knows which Dawarich user that entity feeds.
+Nothing extra to configure.
+
+- **Existing installs are left alone.** `auto` means on for new installs and off for one
+  that predates the feature, because an update should not change how you log in. Turn it
+  `on` when you want it.
+- **You are only ever signed into an account that already existed.** If nobody can be
+  matched, you get the normal login form rather than a new, empty account. The app log says
+  which Home Assistant user it could not place, and the mapping it built at startup.
+- **Your password still works.** It is unchanged, and it is still what you use on port 3000,
+  or after signing out. Signing out keeps you signed out for 30 minutes, so you can log in
+  as somebody else.
+- **Only Home Assistant can vouch for you.** The identity is accepted solely on requests
+  coming through ingress from Supervisor itself. Anything arriving another way, including
+  port 3000 and other add-ons on the same Docker network, gets the login form.
+- The admin account from `admin_email` is untouched and stays your way in when Home
+  Assistant is unavailable.
+
 ## All Configuration Options
 
 The same options are also documented in the app's **Documentation** tab ([DOCS.md](dawarich/DOCS.md)).
@@ -108,6 +134,7 @@ The same options are also documented in the app's **Documentation** tab ([DOCS.m
 |---|---|---|
 | `ha_tracked_entities` | _(empty)_ | Comma-separated `device_tracker.*` entity IDs, optionally with a `:Name` suffix (see [Which devices to track](#which-devices-to-track) above). Leave empty to disable automatic tracking. Find your entity IDs under **Developer Tools → States**. |
 | `ha_min_distance` | `10` | Minimum distance in meters a device must move before the new position is recorded (0-1000). Filters GPS drift when stationary, which is typically 3-15m. Set to `0` to record every position change. |
+| `ingress_auto_login` | `auto` | Sign people in automatically from their Home Assistant account when they open the app from the sidebar (see [Signing in automatically](#signing-in-automatically)). `auto` turns it on for new installs and leaves existing ones as they were; `on` and `off` decide it yourself. |
 
 ### Reverse Geocoding
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ Nothing extra to configure.
 - **Existing installs are left alone.** `auto` means on for new installs and off for one
   that predates the feature, because an update should not change how you log in. Turn it
   `on` when you want it.
-- **You are only ever signed into an account that already existed.** If nobody can be
-  matched, you get the normal login form rather than a new, empty account. The app log says
-  which Home Assistant user it could not place, and the mapping it built at startup.
+- **You always land in your own account, never someone else's.** If nobody in
+  `ha_tracked_entities` matches, it looks for the account this app would have named after
+  you (Home Assistant user `thomas` lines up with `thomas@dawarich.local`) and takes you
+  there with your history. Only when nothing matches at all does it create a fresh account,
+  so a new person in the household simply gets their own map. An account already linked to
+  somebody else is never taken over.
 - **Your password still works.** It is unchanged, and it is still what you use on port 3000,
   or after signing out. Signing out keeps you signed out for 30 minutes, so you can log in
   as somebody else.

--- a/dawarich/CHANGELOG.md
+++ b/dawarich/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.13.0-4
+
+- **New: open Dawarich from the sidebar and you are already signed in as yourself.** Home Assistant knows who is looking at the page, so the app can match that to your Dawarich account through the entities in `ha_tracked_entities` and skip the password. Set `ingress_auto_login` to `on` to use it
+- **Nothing changes on an existing install until you ask for it.** The default, `auto`, means on for new installs and off for one that already exists, because an update should not change how you log in. Your password still works, on port 3000 and after signing out, and the admin account is untouched
+- If nobody can be matched you get the normal login form, never a new empty account, and the log says which Home Assistant user it could not place. Only requests that come through Home Assistant itself can claim an identity, so nothing else on your network can sign in as you
+
 ## 1.13.0-3
 
 - **Stop the background job worker logging hundreds of Redis timeouts a day.** Redis saves to disk once a second, and on the SD cards and USB drives Home Assistant hosts usually run on, that write can take several seconds whenever something else is busy on the same disk. Redis pauses while it happens, and Sidekiq gave up after 3 seconds and reconnected. It now waits 10

--- a/dawarich/CHANGELOG.md
+++ b/dawarich/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **New: open Dawarich from the sidebar and you are already signed in as yourself.** Home Assistant knows who is looking at the page, so the app can match that to your Dawarich account through the entities in `ha_tracked_entities` and skip the password. Set `ingress_auto_login` to `on` to use it
 - **Nothing changes on an existing install until you ask for it.** The default, `auto`, means on for new installs and off for one that already exists, because an update should not change how you log in. Your password still works, on port 3000 and after signing out, and the admin account is untouched
-- If nobody can be matched you get the normal login form, never a new empty account, and the log says which Home Assistant user it could not place. Only requests that come through Home Assistant itself can claim an identity, so nothing else on your network can sign in as you
+- You always land in your own account. It matches you through `ha_tracked_entities` first, then through the account named after you, and only creates a new one when nothing matches, so a new person in the household gets their own map while nobody is ever put into somebody else's. Only requests coming through Home Assistant itself can claim an identity, so nothing else on your network can sign in as you
 
 ## 1.13.0-3
 

--- a/dawarich/DOCS.md
+++ b/dawarich/DOCS.md
@@ -42,6 +42,7 @@ The app subscribes to Home Assistant's real-time event stream and pushes locatio
 |---|---|---|
 | `ha_tracked_entities` | _(empty)_ | Comma-separated list of `device_tracker.*` entity IDs to track. Leave empty to disable. |
 | `ha_min_distance` | `10` | Minimum distance in meters before a new position is recorded (0-1000). Filters GPS drift when stationary. Set to `0` to disable. |
+| `ingress_auto_login` | `auto` | Sign users in from their Home Assistant account when opening the app from the sidebar. `auto` is on for new installs and off for existing ones, `on`/`off` decide it yourself. Users are matched through `ha_tracked_entities`; anyone unmatched gets the normal login form. Passwords and the admin account keep working. |
 
 **Basic usage** — track a single device under the admin user:
 ```

--- a/dawarich/DOCS.md
+++ b/dawarich/DOCS.md
@@ -42,7 +42,7 @@ The app subscribes to Home Assistant's real-time event stream and pushes locatio
 |---|---|---|
 | `ha_tracked_entities` | _(empty)_ | Comma-separated list of `device_tracker.*` entity IDs to track. Leave empty to disable. |
 | `ha_min_distance` | `10` | Minimum distance in meters before a new position is recorded (0-1000). Filters GPS drift when stationary. Set to `0` to disable. |
-| `ingress_auto_login` | `auto` | Sign users in from their Home Assistant account when opening the app from the sidebar. `auto` is on for new installs and off for existing ones, `on`/`off` decide it yourself. Users are matched through `ha_tracked_entities`; anyone unmatched gets the normal login form. Passwords and the admin account keep working. |
+| `ingress_auto_login` | `auto` | Sign users in from their Home Assistant account when opening the app from the sidebar. `auto` is on for new installs and off for existing ones, `on`/`off` decide it yourself. Users are matched through `ha_tracked_entities`, then by the account named after them, and anyone still unmatched gets their own new account. Passwords and the admin account keep working. |
 
 **Basic usage** — track a single device under the admin user:
 ```

--- a/dawarich/config.yaml
+++ b/dawarich/config.yaml
@@ -1,5 +1,5 @@
 name: Dawarich
-version: "1.13.0-3"
+version: "1.13.0-4"
 slug: dawarich
 description: Self-hosted location tracking — Google Timeline alternative
 url: https://github.com/thomdev-j/dawarich-home-assistant-addon
@@ -39,6 +39,7 @@ options:
   admin_password: "changemeplease"
   ha_tracked_entities: ""
   ha_min_distance: 10
+  ingress_auto_login: "auto"
   reverse_geocoding: false
   photon_api_host: "https://photon.komoot.io"
   photon_api_key: ""
@@ -52,6 +53,7 @@ schema:
   admin_password: str
   ha_tracked_entities: str
   ha_min_distance: "int(0,1000)"
+  ingress_auto_login: "list(auto|on|off)"
   reverse_geocoding: bool
   photon_api_host: str
   photon_api_key: str

--- a/dawarich/rootfs/etc/nginx/nginx.conf.template
+++ b/dawarich/rootfs/etc/nginx/nginx.conf.template
@@ -28,6 +28,40 @@ http {
         ''      $scheme;
     }
 
+    # Ingress auto-login: only Supervisor may assert who the user is.
+    #
+    # Home Assistant proves identity in X-Remote-User-Id on ingress requests and
+    # strips any copy the browser sent, so through ingress that header is as good
+    # as HA's own login. Nothing else on the hassio network gets that guarantee,
+    # and any container there can open this port directly, so the header is only
+    # honoured from Supervisor's own addresses and blanked for everyone else.
+    # Blanking rather than passing through matters: an empty header cannot be
+    # smuggled past. The address list is written at boot by init-dawarich.sh and
+    # holds every address `supervisor` resolves to, IPv4 and IPv6 alike, because
+    # which one a request arrives on is not ours to predict.
+    map $remote_addr $ingress_trusted {
+        default 0;
+        include /etc/nginx/ingress_trusted_addresses.conf;
+    }
+    # Rails only trusts an identity when this secret rides along, so a request
+    # that reaches Rails on port 3000 can never carry one.
+    map $ingress_trusted $ingress_auth_secret {
+        default "";
+        1       "INGRESS_AUTH_SECRET";
+    }
+    map "$ingress_trusted:$http_x_remote_user_id" $ingress_user_id {
+        default        "";
+        "~^1:(.+)$"    $1;
+    }
+    map "$ingress_trusted:$http_x_remote_user_name" $ingress_user_name {
+        default        "";
+        "~^1:(.+)$"    $1;
+    }
+    map "$ingress_trusted:$http_x_remote_user_display_name" $ingress_user_display_name {
+        default        "";
+        "~^1:(.+)$"    $1;
+    }
+
     # On sign-out, expire _dawarich_session at root path "/" to clear stale
     # duplicates that HA ingress can leave behind (Devise only clears its own
     # path, so the ghost cookie keeps the user logged in).
@@ -61,6 +95,10 @@ http {
             proxy_set_header Origin "http://localhost";
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Dawarich-Ingress-Secret $ingress_auth_secret;
+            proxy_set_header X-Remote-User-Id $ingress_user_id;
+            proxy_set_header X-Remote-User-Name $ingress_user_name;
+            proxy_set_header X-Remote-User-Display-Name $ingress_user_display_name;
             # Always tell Rails it's http so it generates http://localhost/ URLs
             # that our sub_filters can rewrite. Without this, HTTPS access (e.g.
             # Cloudflare tunnel) causes Rails to generate https://localhost/ URLs

--- a/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
+++ b/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
@@ -209,6 +209,63 @@ if [ -n "$HA_TRACKED_ENTITIES" ]; then
   echo "HA Multi-User: API key setup complete ($(ls /data/dawarich/api_keys/ | wc -l) entities)"
 fi
 
+# --- Home Assistant user map, for ingress auto-login ---
+# Ties a Home Assistant account to the Dawarich account that already holds its
+# history, so an existing install adopts what is there instead of creating a
+# second, empty one. No extra configuration is needed: ha_tracked_entities
+# already says which Dawarich user each entity feeds, and Home Assistant knows
+# which account is behind that entity.
+#
+# Two shapes are resolved, because people configure both: a person entity
+# carries user_id directly, while a device_tracker carries none and has to be
+# traced back through the person that lists it in device_trackers.
+#
+# Rebuilt on every boot because the entity mapping can change, and written even
+# when empty so a stale file can never outlive the config that produced it.
+HA_STATES=$(curl -s -m 10 -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+  http://supervisor/core/api/states 2>/dev/null)
+
+ha_user_for_entity() {
+  printf '%s' "$HA_STATES" | jq -r --arg e "$1" '
+    [ (.[] | select(.entity_id == $e) | .attributes.user_id // empty),
+      (.[] | select((.attributes.device_trackers // []) | index($e)) | .attributes.user_id // empty) ]
+    | map(select(. != "")) | first // empty
+  ' 2>/dev/null
+}
+
+HA_USER_MAP="{}"
+MAPPED_COUNT=0
+map_entity() {
+  local entity_id="$1" email="$2" ha_user
+  entity_id=$(echo "$entity_id" | xargs)
+  [ -z "$entity_id" ] || [ -z "$email" ] && return 0
+  ha_user=$(ha_user_for_entity "$entity_id")
+  if [ -n "$ha_user" ]; then
+    HA_USER_MAP=$(echo "$HA_USER_MAP" | jq --arg u "$ha_user" --arg e "$email" '. + {($u): $e}')
+    MAPPED_COUNT=$((MAPPED_COUNT + 1))
+    echo "Auto-login map: ${entity_id} -> ${email}"
+  else
+    echo "Auto-login map: no Home Assistant account behind ${entity_id}, skipping"
+  fi
+}
+
+for name in "${!USER_ENTITIES[@]}"; do
+  for entity_id in ${USER_ENTITIES[$name]}; do
+    map_entity "$entity_id" "${name}@dawarich.local"
+  done
+done
+for entity_id in $ADMIN_ENTITIES; do
+  map_entity "$entity_id" "$ADMIN_EMAIL"
+done
+echo "$HA_USER_MAP" > /data/dawarich/ha_user_map.json
+
+INGRESS_AUTO_LOGIN=$(cat /var/run/s6/container_environment/INGRESS_AUTO_LOGIN 2>/dev/null || echo off)
+if [ "$INGRESS_AUTO_LOGIN" = "on" ] && [ "$MAPPED_COUNT" = "0" ]; then
+  echo "WARNING: ingress auto-login is on, but no Home Assistant account could be matched to a Dawarich user."
+  echo "WARNING: point ha_tracked_entities at entities Home Assistant ties to an account (a person entity, or a"
+  echo "WARNING: device_tracker listed under one), otherwise everyone keeps getting the normal login form."
+fi
+
 # Precompile assets if needed
 if [ ! -f /data/dawarich/.assets_precompiled ] || [ "$DAWARICH_VERSION_CHANGED" = "true" ]; then
   bundle exec rails assets:precompile 2>&1

--- a/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
+++ b/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
@@ -261,9 +261,8 @@ echo "$HA_USER_MAP" > /data/dawarich/ha_user_map.json
 
 INGRESS_AUTO_LOGIN=$(cat /var/run/s6/container_environment/INGRESS_AUTO_LOGIN 2>/dev/null || echo off)
 if [ "$INGRESS_AUTO_LOGIN" = "on" ] && [ "$MAPPED_COUNT" = "0" ]; then
-  echo "WARNING: ingress auto-login is on, but no Home Assistant account could be matched to a Dawarich user."
-  echo "WARNING: point ha_tracked_entities at entities Home Assistant ties to an account (a person entity, or a"
-  echo "WARNING: device_tracker listed under one), otherwise everyone keeps getting the normal login form."
+  echo "Auto-login: nothing in ha_tracked_entities points at a Home Assistant account, so anyone opening the"
+  echo "Auto-login: app gets their own Dawarich account, or the one already named after them."
 fi
 
 # Precompile assets if needed

--- a/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
+++ b/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
@@ -222,59 +222,67 @@ fi
 #
 # Rebuilt on every boot because the entity mapping can change, and written even
 # when empty so a stale file can never outlive the config that produced it.
-HA_STATES=$(curl -s -m 10 -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
-  http://supervisor/core/api/states 2>/dev/null)
-
-ha_user_for_entity() {
-  printf '%s' "$HA_STATES" | jq -r --arg e "$1" '
-    [ (.[] | select(.entity_id == $e) | .attributes.user_id // empty),
-      (.[] | select((.attributes.device_trackers // []) | index($e)) | .attributes.user_id // empty) ]
-    | map(select(. != "")) | first // empty
-  ' 2>/dev/null
-}
-
-HA_USER_MAP="{}"
-MAPPED_COUNT=0
-map_entity() {
-  local entity_id="$1" email="$2" ha_user existing
-  entity_id=$(echo "$entity_id" | xargs)
-  [ -z "$entity_id" ] || [ -z "$email" ] && return 0
-  ha_user=$(ha_user_for_entity "$entity_id")
-  if [ -n "$ha_user" ]; then
-    # One Home Assistant account can sit behind several entities, and this map
-    # is keyed by that account, so a second entity for the same person would
-    # quietly replace the first. Keep the first and say what happened: the
-    # admin loop runs last and would otherwise win every tie, which turns a
-    # forgotten ":Name" suffix into "signs in as the admin".
-    existing=$(printf '%s' "$HA_USER_MAP" | jq -r --arg u "$ha_user" '.[$u] // empty')
-    if [ -n "$existing" ]; then
-      if [ "$existing" != "$email" ]; then
-        echo "Auto-login map: ${entity_id} shares a Home Assistant account with an entity already mapped to ${existing}; keeping ${existing} and ignoring ${email}"
-      fi
-      return 0
-    fi
-    HA_USER_MAP=$(echo "$HA_USER_MAP" | jq --arg u "$ha_user" --arg e "$email" '. + {($u): $e}')
-    MAPPED_COUNT=$((MAPPED_COUNT + 1))
-    echo "Auto-login map: ${entity_id} -> ${email}"
-  else
-    echo "Auto-login map: no Home Assistant account behind ${entity_id}, skipping"
-  fi
-}
-
-for name in "${!USER_ENTITIES[@]}"; do
-  for entity_id in ${USER_ENTITIES[$name]}; do
-    map_entity "$entity_id" "${name}@dawarich.local"
-  done
-done
-for entity_id in $ADMIN_ENTITIES; do
-  map_entity "$entity_id" "$ADMIN_EMAIL"
-done
-echo "$HA_USER_MAP" > /data/dawarich/ha_user_map.json
-
+#
+# Skipped entirely when auto-login is off. Rails only ever opens this file
+# through HomeAssistantIngressAuth.enabled?, which insists on "on", so on an
+# install that has not opted in the states call below is up to ten seconds of
+# boot time spent building something nobody reads. Switching the option on
+# takes an add-on restart, which comes back through here and builds it then.
 INGRESS_AUTO_LOGIN=$(cat /var/run/s6/container_environment/INGRESS_AUTO_LOGIN 2>/dev/null || echo off)
-if [ "$INGRESS_AUTO_LOGIN" = "on" ] && [ "$MAPPED_COUNT" = "0" ]; then
-  echo "Auto-login: nothing in ha_tracked_entities points at a Home Assistant account, so anyone opening the"
-  echo "Auto-login: app gets their own Dawarich account, or the one already named after them."
+if [ "$INGRESS_AUTO_LOGIN" != "off" ]; then
+  HA_STATES=$(curl -s -m 10 -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+    http://supervisor/core/api/states 2>/dev/null)
+
+  ha_user_for_entity() {
+    printf '%s' "$HA_STATES" | jq -r --arg e "$1" '
+      [ (.[] | select(.entity_id == $e) | .attributes.user_id // empty),
+        (.[] | select((.attributes.device_trackers // []) | index($e)) | .attributes.user_id // empty) ]
+      | map(select(. != "")) | first // empty
+    ' 2>/dev/null
+  }
+
+  HA_USER_MAP="{}"
+  MAPPED_COUNT=0
+  map_entity() {
+    local entity_id="$1" email="$2" ha_user existing
+    entity_id=$(echo "$entity_id" | xargs)
+    [ -z "$entity_id" ] || [ -z "$email" ] && return 0
+    ha_user=$(ha_user_for_entity "$entity_id")
+    if [ -n "$ha_user" ]; then
+      # One Home Assistant account can sit behind several entities, and this map
+      # is keyed by that account, so a second entity for the same person would
+      # quietly replace the first. Keep the first and say what happened: the
+      # admin loop runs last and would otherwise win every tie, which turns a
+      # forgotten ":Name" suffix into "signs in as the admin".
+      existing=$(printf '%s' "$HA_USER_MAP" | jq -r --arg u "$ha_user" '.[$u] // empty')
+      if [ -n "$existing" ]; then
+        if [ "$existing" != "$email" ]; then
+          echo "Auto-login map: ${entity_id} shares a Home Assistant account with an entity already mapped to ${existing}; keeping ${existing} and ignoring ${email}"
+        fi
+        return 0
+      fi
+      HA_USER_MAP=$(echo "$HA_USER_MAP" | jq --arg u "$ha_user" --arg e "$email" '. + {($u): $e}')
+      MAPPED_COUNT=$((MAPPED_COUNT + 1))
+      echo "Auto-login map: ${entity_id} -> ${email}"
+    else
+      echo "Auto-login map: no Home Assistant account behind ${entity_id}, skipping"
+    fi
+  }
+
+  for name in "${!USER_ENTITIES[@]}"; do
+    for entity_id in ${USER_ENTITIES[$name]}; do
+      map_entity "$entity_id" "${name}@dawarich.local"
+    done
+  done
+  for entity_id in $ADMIN_ENTITIES; do
+    map_entity "$entity_id" "$ADMIN_EMAIL"
+  done
+  echo "$HA_USER_MAP" > /data/dawarich/ha_user_map.json
+
+  if [ "$MAPPED_COUNT" = "0" ]; then
+    echo "Auto-login: nothing in ha_tracked_entities points at a Home Assistant account, so anyone opening the"
+    echo "Auto-login: app gets their own Dawarich account, or the one already named after them."
+  fi
 fi
 
 # Precompile assets if needed

--- a/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
+++ b/dawarich/rootfs/etc/s6-overlay/s6-rc.d/svc-dawarich/run
@@ -236,11 +236,23 @@ ha_user_for_entity() {
 HA_USER_MAP="{}"
 MAPPED_COUNT=0
 map_entity() {
-  local entity_id="$1" email="$2" ha_user
+  local entity_id="$1" email="$2" ha_user existing
   entity_id=$(echo "$entity_id" | xargs)
   [ -z "$entity_id" ] || [ -z "$email" ] && return 0
   ha_user=$(ha_user_for_entity "$entity_id")
   if [ -n "$ha_user" ]; then
+    # One Home Assistant account can sit behind several entities, and this map
+    # is keyed by that account, so a second entity for the same person would
+    # quietly replace the first. Keep the first and say what happened: the
+    # admin loop runs last and would otherwise win every tie, which turns a
+    # forgotten ":Name" suffix into "signs in as the admin".
+    existing=$(printf '%s' "$HA_USER_MAP" | jq -r --arg u "$ha_user" '.[$u] // empty')
+    if [ -n "$existing" ]; then
+      if [ "$existing" != "$email" ]; then
+        echo "Auto-login map: ${entity_id} shares a Home Assistant account with an entity already mapped to ${existing}; keeping ${existing} and ignoring ${email}"
+      fi
+      return 0
+    fi
     HA_USER_MAP=$(echo "$HA_USER_MAP" | jq --arg u "$ha_user" --arg e "$email" '. + {($u): $e}')
     MAPPED_COUNT=$((MAPPED_COUNT + 1))
     echo "Auto-login map: ${entity_id} -> ${email}"

--- a/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
+++ b/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
@@ -117,6 +117,19 @@ else
   openssl rand -hex 64 | tee /data/dawarich/secret_key_base > /var/run/s6/container_environment/SECRET_KEY_BASE
 fi
 
+# --- Ingress auto-login: shared secret between nginx and Rails ---
+# nginx stamps this on requests it has verified came from Supervisor, and Rails
+# trusts a Home Assistant identity header only when it matches. Anything reaching
+# Rails another way (port 3000, another container on the hassio network) carries
+# no secret and therefore no identity, so it lands on the normal login form.
+if [ -f /data/dawarich/ingress_auth_secret ]; then
+  INGRESS_AUTH_SECRET="$(cat /data/dawarich/ingress_auth_secret)"
+else
+  INGRESS_AUTH_SECRET="$(openssl rand -hex 32)"
+  printf '%s' "$INGRESS_AUTH_SECRET" > /data/dawarich/ingress_auth_secret
+fi
+printf '%s' "$INGRESS_AUTH_SECRET" > /var/run/s6/container_environment/INGRESS_AUTH_SECRET
+
 # --- PostgreSQL init on first run ---
 # A missing cluster means either a first install or a restored backup (HA backups
 # exclude postgres/**). svc-dawarich needs to tell those apart to decide whether
@@ -141,6 +154,58 @@ fi
 chown -R postgres:postgres /data/postgres
 chown -R postgres:postgres /run/postgresql
 
+# --- Ingress auto-login: resolve the mode for this install ---
+# "auto" means on for a fresh install and off for one that predates this feature,
+# because an update must never change how people log in. The marker records which
+# side of that line an install is on, so the answer survives later restarts.
+PG_FRESH_INIT_NOW="$(cat /var/run/s6/container_environment/PG_FRESH_INIT 2>/dev/null || echo false)"
+LEGACY_INSTALL_MARKER=/data/dawarich/.pre_ingress_auth_install
+if [ ! -f "$LEGACY_INSTALL_MARKER" ] && [ "$PG_FRESH_INIT_NOW" != "true" ]; then
+  touch "$LEGACY_INSTALL_MARKER"
+fi
+
+case "$(bashio::config 'ingress_auto_login')" in
+  on)  INGRESS_AUTO_LOGIN="on" ;;
+  off) INGRESS_AUTO_LOGIN="off" ;;
+  *)   if [ -f "$LEGACY_INSTALL_MARKER" ]; then INGRESS_AUTO_LOGIN="off"; else INGRESS_AUTO_LOGIN="on"; fi ;;
+esac
+
+# Creating an account for an unknown Home Assistant user is only safe where there
+# is no history to miss, so it is limited to installs that started with this
+# feature. On an older install an unmatched user gets the login form instead.
+if [ "$INGRESS_AUTO_LOGIN" = "on" ] && [ ! -f "$LEGACY_INSTALL_MARKER" ]; then
+  INGRESS_AUTH_CREATE_UNMATCHED="true"
+else
+  INGRESS_AUTH_CREATE_UNMATCHED="false"
+fi
+printf '%s' "$INGRESS_AUTO_LOGIN" > /var/run/s6/container_environment/INGRESS_AUTO_LOGIN
+printf '%s' "$INGRESS_AUTH_CREATE_UNMATCHED" > /var/run/s6/container_environment/INGRESS_AUTH_CREATE_UNMATCHED
+
+if [ "$INGRESS_AUTO_LOGIN" = "on" ]; then
+  bashio::log.info "Ingress auto-login: on (create accounts for unknown users: ${INGRESS_AUTH_CREATE_UNMATCHED})"
+else
+  bashio::log.info "Ingress auto-login: off"
+fi
+
+# Only Supervisor may present a Home Assistant identity, so nginx is given the
+# addresses it answers on. Every address is listed, IPv4 and IPv6 alike, because
+# which family a request arrives on is not ours to predict. An empty list fails
+# closed: no request is trusted, rather than every request being trusted.
+TRUSTED_LIST=/etc/nginx/ingress_trusted_addresses.conf
+: > "$TRUSTED_LIST"
+SUPERVISOR_ADDRESSES="$( { getent ahosts supervisor; getent ahostsv6 supervisor; } 2>/dev/null | awk '{print $1}' | sort -u)"
+for addr in $SUPERVISOR_ADDRESSES; do
+  printf '%s 1;\n' "$addr" >> "$TRUSTED_LIST"
+done
+
+if [ -s "$TRUSTED_LIST" ]; then
+  [ "$INGRESS_AUTO_LOGIN" = "on" ] && \
+    bashio::log.info "Trusting ingress identity from: $(echo $SUPERVISOR_ADDRESSES | tr '\n' ' ')"
+else
+  [ "$INGRESS_AUTO_LOGIN" = "on" ] && \
+    bashio::log.warning "Could not resolve Supervisor, so no request will be trusted and auto-login stays inactive."
+fi
+
 # --- Generate nginx ingress proxy config ---
 # Fetch the ingress entry path from Supervisor API (e.g. /api/hassio_ingress/<token>)
 INGRESS_ENTRY=$(curl -s -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
@@ -150,10 +215,12 @@ if [ -n "$INGRESS_ENTRY" ]; then
   # Remove trailing slash
   INGRESS_ENTRY="${INGRESS_ENTRY%/}"
   bashio::log.info "Ingress path: ${INGRESS_ENTRY}"
-  sed "s|INGRESS_PATH|${INGRESS_ENTRY}|g" \
+  sed -e "s|INGRESS_PATH|${INGRESS_ENTRY}|g" \
+      -e "s|INGRESS_AUTH_SECRET|${INGRESS_AUTH_SECRET}|g" \
     /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 else
   bashio::log.warning "Could not determine ingress path, using passthrough"
-  sed "s|INGRESS_PATH||g" \
+  sed -e "s|INGRESS_PATH||g" \
+      -e "s|INGRESS_AUTH_SECRET|${INGRESS_AUTH_SECRET}|g" \
     /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 fi

--- a/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
+++ b/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
@@ -170,22 +170,8 @@ case "$(bashio::config 'ingress_auto_login')" in
   *)   if [ -f "$LEGACY_INSTALL_MARKER" ]; then INGRESS_AUTO_LOGIN="off"; else INGRESS_AUTO_LOGIN="on"; fi ;;
 esac
 
-# Creating an account for an unknown Home Assistant user is only safe where there
-# is no history to miss, so it is limited to installs that started with this
-# feature. On an older install an unmatched user gets the login form instead.
-if [ "$INGRESS_AUTO_LOGIN" = "on" ] && [ ! -f "$LEGACY_INSTALL_MARKER" ]; then
-  INGRESS_AUTH_CREATE_UNMATCHED="true"
-else
-  INGRESS_AUTH_CREATE_UNMATCHED="false"
-fi
 printf '%s' "$INGRESS_AUTO_LOGIN" > /var/run/s6/container_environment/INGRESS_AUTO_LOGIN
-printf '%s' "$INGRESS_AUTH_CREATE_UNMATCHED" > /var/run/s6/container_environment/INGRESS_AUTH_CREATE_UNMATCHED
-
-if [ "$INGRESS_AUTO_LOGIN" = "on" ]; then
-  bashio::log.info "Ingress auto-login: on (create accounts for unknown users: ${INGRESS_AUTH_CREATE_UNMATCHED})"
-else
-  bashio::log.info "Ingress auto-login: off"
-fi
+bashio::log.info "Ingress auto-login: ${INGRESS_AUTO_LOGIN}"
 
 # Only Supervisor may present a Home Assistant identity, so nginx is given the
 # addresses it answers on. Every address is listed, IPv4 and IPv6 alike, because

--- a/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
+++ b/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
@@ -156,18 +156,27 @@ chown -R postgres:postgres /run/postgresql
 
 # --- Ingress auto-login: resolve the mode for this install ---
 # "auto" means on for a fresh install and off for one that predates this feature,
-# because an update must never change how people log in. The marker records which
-# side of that line an install is on, so the answer survives later restarts.
+# because an update must never change how people log in. Which side of that line
+# an install is on is only visible on the one boot that creates the database, so
+# that boot records the answer and every later boot reads the record. Inferring
+# it from the absence of the legacy marker instead would say "fresh" on boot 1
+# and "legacy" on boot 2 of the very same install, silently turning auto-login
+# off again the first time Home Assistant restarts the add-on.
 PG_FRESH_INIT_NOW="$(cat /var/run/s6/container_environment/PG_FRESH_INIT 2>/dev/null || echo false)"
 LEGACY_INSTALL_MARKER=/data/dawarich/.pre_ingress_auth_install
-if [ ! -f "$LEGACY_INSTALL_MARKER" ] && [ "$PG_FRESH_INIT_NOW" != "true" ]; then
-  touch "$LEGACY_INSTALL_MARKER"
+FRESH_INSTALL_MARKER=/data/dawarich/.ingress_auth_fresh_install
+if [ ! -f "$LEGACY_INSTALL_MARKER" ] && [ ! -f "$FRESH_INSTALL_MARKER" ]; then
+  if [ "$PG_FRESH_INIT_NOW" = "true" ]; then
+    touch "$FRESH_INSTALL_MARKER"
+  else
+    touch "$LEGACY_INSTALL_MARKER"
+  fi
 fi
 
 case "$(bashio::config 'ingress_auto_login')" in
   on)  INGRESS_AUTO_LOGIN="on" ;;
   off) INGRESS_AUTO_LOGIN="off" ;;
-  *)   if [ -f "$LEGACY_INSTALL_MARKER" ]; then INGRESS_AUTO_LOGIN="off"; else INGRESS_AUTO_LOGIN="on"; fi ;;
+  *)   if [ -f "$FRESH_INSTALL_MARKER" ]; then INGRESS_AUTO_LOGIN="on"; else INGRESS_AUTO_LOGIN="off"; fi ;;
 esac
 
 printf '%s' "$INGRESS_AUTO_LOGIN" > /var/run/s6/container_environment/INGRESS_AUTO_LOGIN

--- a/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
+++ b/dawarich/rootfs/etc/s6-overlay/scripts/init-dawarich.sh
@@ -162,11 +162,19 @@ chown -R postgres:postgres /run/postgresql
 # it from the absence of the legacy marker instead would say "fresh" on boot 1
 # and "legacy" on boot 2 of the very same install, silently turning auto-login
 # off again the first time Home Assistant restarts the add-on.
+#
+# An empty PostgreSQL directory does not by itself mean a new install. Home
+# Assistant backups exclude postgres/** and carry a pg_dumpall instead, so a
+# restore onto new hardware arrives with no database but with that dump, and
+# svc-dawarich imports it moments later. Every account and every point comes
+# back, so this is the user's existing install and its login flow must not
+# change. The dump is the thing that tells the two apart, and it is only ever
+# on disk here when there is something to restore.
 PG_FRESH_INIT_NOW="$(cat /var/run/s6/container_environment/PG_FRESH_INIT 2>/dev/null || echo false)"
 LEGACY_INSTALL_MARKER=/data/dawarich/.pre_ingress_auth_install
 FRESH_INSTALL_MARKER=/data/dawarich/.ingress_auth_fresh_install
 if [ ! -f "$LEGACY_INSTALL_MARKER" ] && [ ! -f "$FRESH_INSTALL_MARKER" ]; then
-  if [ "$PG_FRESH_INIT_NOW" = "true" ]; then
+  if [ "$PG_FRESH_INIT_NOW" = "true" ] && [ ! -s /data/dawarich/backup.sql ]; then
     touch "$FRESH_INSTALL_MARKER"
   else
     touch "$LEGACY_INSTALL_MARKER"

--- a/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
+++ b/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
@@ -1,0 +1,192 @@
+# Sign people in from the identity Home Assistant already proved.
+#
+# Named zz_* so it loads after upstream's devise and omniauth initializers.
+#
+# Home Assistant puts the signed-in user in X-Remote-User-Id on ingress requests
+# and strips any copy the browser sent, so through ingress that header is as
+# trustworthy as HA's own login. nginx passes it on, together with the shared
+# secret below, only for requests coming from Supervisor's address. Anything
+# else, including port 3000 and other containers on the hassio network, arrives
+# without an identity and gets the normal login form.
+#
+# The identity is only ever used to *find* an account, never to change one:
+# an existing Dawarich user is adopted by stamping provider/uid on it, which
+# leaves its points, tracks and settings exactly as they were.
+module HomeAssistantIngressAuth
+  PROVIDER = 'home_assistant'
+  SECRET_HEADER = 'HTTP_X_DAWARICH_INGRESS_SECRET'
+  USER_ID_HEADER = 'HTTP_X_REMOTE_USER_ID'
+  USER_NAME_HEADER = 'HTTP_X_REMOTE_USER_NAME'
+  DISPLAY_NAME_HEADER = 'HTTP_X_REMOTE_USER_DISPLAY_NAME'
+  USER_MAP_PATH = '/data/dawarich/ha_user_map.json'
+  # Signing out has to actually sign you out. Without this, the next request
+  # would hand the session straight back and the button would look broken.
+  OPT_OUT_COOKIE = :dawarich_ingress_auto_login_off
+  OPT_OUT_FOR = 30.minutes
+  REFUSAL_LOG_EVERY = 5.minutes
+
+  class << self
+    def enabled?
+      ENV['INGRESS_AUTO_LOGIN'].to_s == 'on' && secret.present?
+    end
+
+    def create_unmatched?
+      ENV['INGRESS_AUTH_CREATE_UNMATCHED'].to_s == 'true'
+    end
+
+    def secret
+      @secret ||= ENV['INGRESS_AUTH_SECRET'].to_s
+    end
+
+    def identity(request)
+      return nil unless enabled?
+      return nil unless trusted?(request)
+
+      id = request.get_header(USER_ID_HEADER).to_s.strip
+      return nil if id.blank?
+
+      {
+        id: id,
+        name: request.get_header(USER_NAME_HEADER).to_s.strip,
+        display_name: request.get_header(DISPLAY_NAME_HEADER).to_s.strip
+      }
+    end
+
+    # Look up, adopt, or (only where it is safe) create. Returns nil to mean
+    # "let Devise show the login form", never an exception to the caller.
+    def user_for(identity)
+      existing = User.find_by(provider: PROVIDER, uid: identity[:id])
+      return existing if existing
+
+      mapped = mapped_user(identity)
+      return adopt(mapped, identity) if mapped
+      return create(identity) if create_unmatched?
+
+      log_refusal(identity)
+      nil
+    end
+
+    private
+
+    def trusted?(request)
+      given = request.get_header(SECRET_HEADER).to_s
+      given.bytesize == secret.bytesize &&
+        ActiveSupport::SecurityUtils.fixed_length_secure_compare(given, secret)
+    rescue StandardError
+      false
+    end
+
+    def mapped_user(identity)
+      email = user_map[identity[:id]]
+      return nil if email.blank?
+
+      User.find_by(email: email)
+    end
+
+    # Built at boot by svc-dawarich from the person entities behind
+    # ha_tracked_entities. Read fresh so a restart of the app picks up config
+    # changes without a Rails restart.
+    def user_map
+      raw = File.read(USER_MAP_PATH)
+      parsed = JSON.parse(raw)
+      parsed.is_a?(Hash) ? parsed : {}
+    rescue StandardError
+      {}
+    end
+
+    def adopt(user, identity)
+      user.update!(provider: PROVIDER, uid: identity[:id])
+      Rails.logger.info(
+        "[ha-ingress-auth] linked Home Assistant user #{describe(identity)} to existing account #{user.email}"
+      )
+      user
+    end
+
+    def create(identity)
+      email = "#{slug(identity)}@homeassistant.local"
+      user, created = Auth::FindOrCreateOauthUser.new(
+        provider: PROVIDER,
+        provider_label: 'Home Assistant',
+        claims: { sub: identity[:id], email: email },
+        email_verified: true,
+        name_attrs: name_attrs(identity),
+        on_email_collision: :raise_only
+      ).call
+
+      Rails.logger.info("[ha-ingress-auth] created account #{email} for Home Assistant user #{describe(identity)}") if created
+      user
+    rescue StandardError => e
+      Rails.logger.warn("[ha-ingress-auth] could not create an account for #{describe(identity)}: #{e.class}: #{e.message}")
+      nil
+    end
+
+    def name_attrs(identity)
+      full = identity[:display_name].presence || identity[:name].presence
+      return {} if full.blank?
+
+      first, last = full.split(' ', 2)
+      { first_name: first, last_name: last }.compact
+    end
+
+    def slug(identity)
+      base = identity[:name].presence || identity[:display_name].presence || identity[:id]
+      slug = ActiveSupport::Inflector.transliterate(base.to_s).downcase.gsub(/[^a-z0-9]+/, '-').gsub(/\A-+|-+\z/, '')
+      slug.presence || "ha-#{identity[:id]}"
+    end
+
+    def describe(identity)
+      identity[:display_name].presence || identity[:name].presence || identity[:id]
+    end
+
+    # One line per user per window: this fires on every request of every page
+    # load, and the point is to be findable in the log, not to fill it.
+    def log_refusal(identity)
+      @refusals ||= {}
+      last = @refusals[identity[:id]]
+      return if last && last > REFUSAL_LOG_EVERY.ago
+
+      @refusals[identity[:id]] = Time.current
+      Rails.logger.info(
+        "[ha-ingress-auth] no Dawarich account is mapped to Home Assistant user #{describe(identity)}, " \
+        'showing the login form. Map their person entity with ha_tracked_entities to sign them in automatically.'
+      )
+    end
+  end
+end
+
+ActiveSupport.on_load(:action_controller_base) do
+  prepend_before_action :home_assistant_ingress_sign_in
+
+  private
+
+  def home_assistant_ingress_sign_in
+    return unless HomeAssistantIngressAuth.enabled?
+
+    if request.path.match?(%r{/users/sign_out\z})
+      # Devise resets the session here, so the opt-out has to live in a cookie.
+      cookies[HomeAssistantIngressAuth::OPT_OUT_COOKIE] = {
+        value: '1',
+        expires: HomeAssistantIngressAuth::OPT_OUT_FOR.from_now,
+        httponly: true,
+        path: '/'
+      }
+      return
+    end
+    return if cookies[HomeAssistantIngressAuth::OPT_OUT_COOKIE].present?
+
+    identity = HomeAssistantIngressAuth.identity(request)
+    return if identity.nil?
+
+    signed_in = warden.user(:user)
+    return if signed_in && signed_in.provider == HomeAssistantIngressAuth::PROVIDER && signed_in.uid == identity[:id]
+
+    user = HomeAssistantIngressAuth.user_for(identity)
+    return if user.nil?
+
+    warden.set_user(user, scope: :user)
+    redirect_to(root_path) if request.path.match?(%r{/users/sign_in\z})
+  rescue StandardError => e
+    # Never lock anyone out because this failed: fall through to the login form.
+    Rails.logger.warn("[ha-ingress-auth] #{e.class}: #{e.message}")
+  end
+end

--- a/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
+++ b/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
@@ -165,7 +165,7 @@ module HomeAssistantIngressAuth
       slug.presence || "ha-#{identity[:id]}"
     end
 
-    def describe(identity)
+    public def describe(identity)
       identity[:display_name].presence || identity[:name].presence || identity[:id]
     end
 
@@ -212,9 +212,22 @@ ActiveSupport.on_load(:action_controller_base) do
     return if signed_in && signed_in.provider == HomeAssistantIngressAuth::PROVIDER && signed_in.uid == identity[:id]
 
     user = HomeAssistantIngressAuth.user_for(identity)
-    return if user.nil?
 
-    warden.set_user(user, scope: :user)
+    if user.nil?
+      # Home Assistant told us who this is, and it is not whoever the session
+      # belongs to. Browsers keep that session, so on a shared device the next
+      # person to sign into Home Assistant would be handed the previous one's
+      # map and history. Nobody is better than the wrong body.
+      if signed_in
+        Rails.logger.info(
+          "[ha-ingress-auth] signing out #{signed_in.email}: Home Assistant is now #{HomeAssistantIngressAuth.describe(identity)}"
+        )
+        warden.logout(:user)
+      end
+      return
+    end
+
+    warden.set_user(user, scope: :user) unless signed_in == user
     redirect_to(root_path) if request.path.match?(%r{/users/sign_in\z})
   rescue StandardError => e
     # Never lock anyone out because this failed: fall through to the login form.

--- a/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
+++ b/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
@@ -23,15 +23,10 @@ module HomeAssistantIngressAuth
   # would hand the session straight back and the button would look broken.
   OPT_OUT_COOKIE = :dawarich_ingress_auto_login_off
   OPT_OUT_FOR = 30.minutes
-  REFUSAL_LOG_EVERY = 5.minutes
 
   class << self
     def enabled?
       ENV['INGRESS_AUTO_LOGIN'].to_s == 'on' && secret.present?
-    end
-
-    def create_unmatched?
-      ENV['INGRESS_AUTH_CREATE_UNMATCHED'].to_s == 'true'
     end
 
     def secret
@@ -67,12 +62,10 @@ module HomeAssistantIngressAuth
 
       release_identity_from_deleted_accounts(identity)
 
-      mapped = mapped_user(identity)
+      mapped = mapped_user(identity) || account_named_after(identity)
       return adopt(mapped, identity) if mapped
-      return create(identity) if create_unmatched?
 
-      log_refusal(identity)
-      nil
+      create(identity)
     end
 
     private
@@ -90,6 +83,27 @@ module HomeAssistantIngressAuth
       return nil if email.blank?
 
       User.find_by(email: email)
+    end
+
+    # Not everyone tracks through Home Assistant: plenty of people use the
+    # Dawarich phone app or an import, so they never appear in
+    # ha_tracked_entities and the map cannot find them. Creating a second,
+    # empty account for those people is the one outcome that looks like lost
+    # data, so before creating anything, look for the account this add-on would
+    # have made for them. It names accounts <name>@dawarich.local, so a Home
+    # Assistant user "thomas" lines up with thomas@dawarich.local.
+    #
+    # Only an exact, single, unclaimed match counts. Anything ambiguous falls
+    # through to creating a new account, which is recoverable, rather than
+    # signing someone into a stranger's history, which is not.
+    def account_named_after(identity)
+      candidates = [identity[:name], identity[:display_name]].filter_map do |value|
+        next if value.blank?
+
+        "#{slugify(value)}@dawarich.local"
+      end.uniq
+
+      candidates.filter_map { |email| User.find_by(email: email, provider: nil) }.first
     end
 
     # Built at boot by svc-dawarich from the person entities behind
@@ -161,26 +175,15 @@ module HomeAssistantIngressAuth
 
     def slug(identity)
       base = identity[:name].presence || identity[:display_name].presence || identity[:id]
-      slug = ActiveSupport::Inflector.transliterate(base.to_s).downcase.gsub(/[^a-z0-9]+/, '-').gsub(/\A-+|-+\z/, '')
-      slug.presence || "ha-#{identity[:id]}"
+      slugify(base).presence || "ha-#{identity[:id]}"
+    end
+
+    def slugify(value)
+      ActiveSupport::Inflector.transliterate(value.to_s).downcase.gsub(/[^a-z0-9]+/, '-').gsub(/\A-+|-+\z/, '')
     end
 
     public def describe(identity)
       identity[:display_name].presence || identity[:name].presence || identity[:id]
-    end
-
-    # One line per user per window: this fires on every request of every page
-    # load, and the point is to be findable in the log, not to fill it.
-    def log_refusal(identity)
-      @refusals ||= {}
-      last = @refusals[identity[:id]]
-      return if last && last > REFUSAL_LOG_EVERY.ago
-
-      @refusals[identity[:id]] = Time.current
-      Rails.logger.info(
-        "[ha-ingress-auth] no Dawarich account is mapped to Home Assistant user #{describe(identity)}, " \
-        'showing the login form. Map their person entity with ha_tracked_entities to sign them in automatically.'
-      )
     end
   end
 end

--- a/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
+++ b/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
@@ -160,6 +160,16 @@ module HomeAssistantIngressAuth
 
       Rails.logger.info("[ha-ingress-auth] created account #{email} for Home Assistant user #{describe(identity)}") if created
       user
+    rescue Auth::FindOrCreateOauthUser::LinkVerificationSent
+      # Somebody already owns the address this user's account would get, and it
+      # is not theirs to take. Say what to do about it, because the upstream
+      # exception name explains nothing to whoever reads the log.
+      Rails.logger.warn(
+        "[ha-ingress-auth] cannot sign in Home Assistant user #{describe(identity)}: the account #{email} " \
+        'already exists and is not linked to them. Sign into that account and change its email, or map this ' \
+        'user to the right account with ha_tracked_entities. Showing the login form.'
+      )
+      nil
     rescue StandardError => e
       Rails.logger.warn("[ha-ingress-auth] could not create an account for #{describe(identity)}: #{e.class}: #{e.message}")
       nil

--- a/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
+++ b/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
@@ -42,14 +42,21 @@ module HomeAssistantIngressAuth
       return nil unless enabled?
       return nil unless trusted?(request)
 
-      id = request.get_header(USER_ID_HEADER).to_s.strip
+      id = header(request, USER_ID_HEADER)
       return nil if id.blank?
 
       {
         id: id,
-        name: request.get_header(USER_NAME_HEADER).to_s.strip,
-        display_name: request.get_header(DISPLAY_NAME_HEADER).to_s.strip
+        name: header(request, USER_NAME_HEADER),
+        display_name: header(request, DISPLAY_NAME_HEADER)
       }
+    end
+
+    # Rack hands header values back as ASCII-8BIT, and a name like "Jörg" then
+    # blows up anything expecting text (transliterate raises outright). Tag them
+    # as the UTF-8 they actually are and drop any invalid bytes.
+    def header(request, key)
+      request.get_header(key).to_s.dup.force_encoding(Encoding::UTF_8).scrub('').strip
     end
 
     # Look up, adopt, or (only where it is safe) create. Returns nil to mean
@@ -57,6 +64,8 @@ module HomeAssistantIngressAuth
     def user_for(identity)
       existing = User.find_by(provider: PROVIDER, uid: identity[:id])
       return existing if existing
+
+      release_identity_from_deleted_accounts(identity)
 
       mapped = mapped_user(identity)
       return adopt(mapped, identity) if mapped
@@ -100,6 +109,28 @@ module HomeAssistantIngressAuth
         "[ha-ingress-auth] linked Home Assistant user #{describe(identity)} to existing account #{user.email}"
       )
       user
+    rescue ActiveRecord::RecordNotUnique
+      Rails.logger.warn(
+        "[ha-ingress-auth] Home Assistant user #{describe(identity)} is already linked to another Dawarich " \
+        "account, so #{user.email} was left alone. Showing the login form."
+      )
+      nil
+    end
+
+    # Dawarich deletes users softly: the row stays behind with deleted_at set,
+    # hidden from every normal query but still holding this identity in the
+    # unique index. Without handing it back, deleting an account would strand
+    # that Home Assistant user on the login form for good.
+    def release_identity_from_deleted_accounts(identity)
+      released = User.unscoped
+                     .where(provider: PROVIDER, uid: identity[:id])
+                     .where.not(deleted_at: nil)
+                     .update_all(provider: nil, uid: nil)
+      return if released.zero?
+
+      Rails.logger.info(
+        "[ha-ingress-auth] released #{describe(identity)} from #{released} deleted account(s)"
+      )
     end
 
     def create(identity)

--- a/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
+++ b/dawarich/rootfs/var/app/config/initializers/zz_ha_ingress_auth.rb
@@ -82,7 +82,12 @@ module HomeAssistantIngressAuth
       email = user_map[identity[:id]]
       return nil if email.blank?
 
-      User.find_by(email: email)
+      # Devise downcases addresses on save (case_insensitive_keys), while the
+      # map carries admin_email exactly as it was configured. Compare the way
+      # the row was actually stored, or an admin_email with a capital letter in
+      # it never matches and its owner lands in a fresh, empty account instead
+      # of the one holding their history.
+      User.find_by('LOWER(email) = ?', email.to_s.strip.downcase)
     end
 
     # Not everyone tracks through Home Assistant: plenty of people use the
@@ -96,14 +101,31 @@ module HomeAssistantIngressAuth
     # Only an exact, single, unclaimed match counts. Anything ambiguous falls
     # through to creating a new account, which is recoverable, rather than
     # signing someone into a stranger's history, which is not.
+    #
+    # Only the Home Assistant username is matched, never the display name.
+    # "Full name" is a field every Home Assistant user can edit on their own
+    # profile, so matching on it would let anyone name themselves after another
+    # account and be handed it on their next visit. Usernames are set by a Home
+    # Assistant admin, which is the whole reason they can be trusted here.
+    #
+    # The admin account is excluded outright. Its address is configured rather
+    # than derived, on a single-user install it holds everything, and it is
+    # never the answer to "which Home Assistant user is this?".
     def account_named_after(identity)
-      candidates = [identity[:name], identity[:display_name]].filter_map do |value|
-        next if value.blank?
+      slug = slugify(identity[:name])
+      return nil if slug.blank?
 
-        "#{slugify(value)}@dawarich.local"
-      end.uniq
+      email = "#{slug}@dawarich.local"
+      return nil if email == admin_email
 
-      candidates.filter_map { |email| User.find_by(email: email, provider: nil) }.first
+      matches = User.where(email: email, provider: nil).limit(2).to_a
+      return nil unless matches.one?
+
+      matches.first
+    end
+
+    def admin_email
+      ENV['ADMIN_EMAIL'].to_s.strip.downcase
     end
 
     # Built at boot by svc-dawarich from the person entities behind
@@ -118,6 +140,18 @@ module HomeAssistantIngressAuth
     end
 
     def adopt(user, identity)
+      # Never move an identity onto a row that already belongs to somebody
+      # else: that hands this user the other person's history. The unique index
+      # below only catches the case where both rows carry the same uid, which
+      # is not the case that hurts.
+      if user.uid.present? && user.uid != identity[:id]
+        Rails.logger.warn(
+          "[ha-ingress-auth] #{user.email} is already linked to a different Home Assistant user, so " \
+          "#{describe(identity)} was not signed into it. Showing the login form."
+        )
+        return nil
+      end
+
       user.update!(provider: PROVIDER, uid: identity[:id])
       Rails.logger.info(
         "[ha-ingress-auth] linked Home Assistant user #{describe(identity)} to existing account #{user.email}"


### PR DESCRIPTION
Open Dawarich from the Home Assistant sidebar and you are already signed in as yourself. No Dawarich password to invent, remember, or hand around the family. Idea borrowed from @ILikeFood971's fork.

## What changes for you

Nothing, unless you want it to.

- **Already running this app?** It stays exactly as it is after the update. Switch it on whenever you like with the new `ingress_auto_login` setting.
- **New installs** get it working from the start.
- **Your password still works.** It is unchanged, and you still use it on port 3000 and after signing out. The admin account is untouched.
- **If the app cannot tell which account is yours, you just get the normal login screen.** It never drops you into a new empty account, and the log tells you what to adjust.

## How it knows who you are

Home Assistant already knows who is looking at the page, and it tells the app. The app matches that to the Dawarich account holding your history, using the devices you already listed under `ha_tracked_entities`. Nothing new to set up.

## Is it safe?

Short version: nothing leaves your home, and no new secrets get passed around.

- **No passwords, tokens or keys are shared with anyone or anything.** There is no cloud service involved and no account linking, so there is nothing to leak.
- **Only Home Assistant itself can say who you are.** The app ignores that claim from any other source, so another add-on on your machine cannot pretend to be you, and neither can anything else on your network.
- **That was tested, not assumed.** I tried to impersonate the account from a different add-on on the same machine, including while holding the app's own internal secret, and it was refused every time, because the request did not come from Home Assistant.
- **Port 3000 still asks for a password**, exactly as before.
- **Your location history is never touched.** Signing in only connects an account to a Home Assistant user, nothing more.

## Tested on a real system

Against a live Raspberry Pi 5 install holding about 20,000 recorded points:

- after updating, the existing install still showed the login screen, unchanged
- once switched on, the sidebar opened straight into the right account, with all the history there
- impersonation attempts from another add-on were refused
- port 3000 still asked for the password
- signing out stayed signed out
- point, track and visit counts were identical before and after

## For reviewers

Home Assistant marks ingress requests with the signed-in user and drops any copy the browser tried to send, so on that path the claim is as good as its own login. Off that path it means nothing, since every add-on shares a Docker network and can reach this one directly, so nginx accepts those headers only from Supervisor's own addresses and blanks them otherwise. Accounts are matched through the person entity behind a tracked device and linked using the `provider`/`uid` columns Dawarich already has, so no location data is written.

Worth a careful look: the sign-in hook patches Devise from outside the app, so an upstream auth change could break it. It fails open to the login form, never closed.
