### PR TITLE
Bump Dawarich to 1.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dawarich Home Assistant Add-on (App)
 
-**Current Dawarich version: 1.13.0** ([release notes](https://github.com/Freika/dawarich/releases/tag/1.13.0))
+**Current Dawarich version: 1.13.1** ([release notes](https://github.com/Freika/dawarich/releases/tag/1.13.1))
 
 [![HA App][ha-app-badge]][ha-app-link]
 

--- a/dawarich/CHANGELOG.md
+++ b/dawarich/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.13.1-1
+
+- Upgrade base image to Dawarich [1.13.1](https://github.com/Freika/dawarich/releases/tag/1.13.1). The Tiled rendering beta now draws Tracks, Routes and Fog of War as well, so only the Scratch map still falls back to loading everything up front. It stays off until you switch it on under Map v2 → Settings
+- **Slow first boot, then a background job that can run for hours.** Device and importer details move out of the points table into a shared one, which makes a large history noticeably smaller on disk. Existing points are converted in the background after the upgrade: expect high CPU for a while, and the database to grow before it shrinks, so check the drive has room. Your points, tracks, visits and stats are untouched, nothing changes in the app while it runs, and the app boots normally whether or not it finishes
+- Each account can now pick its own geocoding provider (Photon, Geoapify, Nominatim or LocationIQ) under Settings → Integrations. With `reverse_geocoding` enabled in the app configuration, those options still win and the picker only shows what is already in use. Reverse geocoding also now uses one background worker instead of up to five, which only slows anything down if you point the app at your own Photon server
+- No app config changes required
+
 ## 1.13.0-3
 
 - **Stop the background job worker logging hundreds of Redis timeouts a day.** Redis saves to disk once a second, and on the SD cards and USB drives Home Assistant hosts usually run on, that write can take several seconds whenever something else is busy on the same disk. Redis pauses while it happens, and Sidekiq gave up after 3 seconds and reconnected. It now waits 10

--- a/dawarich/build.yaml
+++ b/dawarich/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: freikin/dawarich:1.13.0
-  amd64: freikin/dawarich:1.13.0
+  aarch64: freikin/dawarich:1.13.1
+  amd64: freikin/dawarich:1.13.1
 args:
   S6_OVERLAY_VERSION: "3.2.2.0"
   BASHIO_VERSION: "0.16.2"

--- a/dawarich/config.yaml
+++ b/dawarich/config.yaml
@@ -1,5 +1,5 @@
 name: Dawarich
-version: "1.13.0-3"
+version: "1.13.1-1"
 slug: dawarich
 description: Self-hosted location tracking — Google Timeline alternative
 url: https://github.com/thomdev-j/dawarich-home-assistant-addon

--- a/dawarich/rootfs/etc/nginx/nginx.conf.template
+++ b/dawarich/rootfs/etc/nginx/nginx.conf.template
@@ -114,8 +114,9 @@ http {
             # so the ingress prefix is missing, and it fetches the tiles from a
             # web worker that the patch script below never reaches. Rewriting
             # the literal in the served JS covers both places it appears: the
-            # URL template in points_mvt_layer.js, and the startsWith() guard in
-            # map_initializer.js that decides whether to attach the API key.
+            # URL templates in points_mvt_layer.js and tracks_mvt_layer.js, and
+            # the startsWith() guard in map_initializer.js that decides whether
+            # to attach the API key.
             sub_filter '"/api/v1/tiles/' '"INGRESS_PATH/api/v1/tiles/';
             sub_filter "'/api/v1/tiles/" "'INGRESS_PATH/api/v1/tiles/";
 


### PR DESCRIPTION
Upstream released [1.13.1](https://github.com/Freika/dawarich/releases/tag/1.13.1) on 2026-08-22. We package 1.13.0.

`freikin/dawarich:1.13.1` is on Docker Hub with `amd64` and `arm64` manifests (plus `arm/v7`), so both add-on arches can build.

## The one thing to look at first

**1.13.1 moves device and importer columns out of `points` into a new `point_sources` table, and backfills every existing point in the background.** On the maintainer's own history this will run for a while, peg one Sidekiq worker, and grow the database before it shrinks. It cannot loop the add-on: the migration that adds `points.source_id` catches its own lock timeout and lets boot continue, and the migration that starts the backfill swallows everything except `NameError`. But it is the single biggest behaviour change in this release for a Home Assistant box, and it is the thing to watch after merging.

No code change turned out to be needed for it, or for anything else in this release. The diff is version bumps, a changelog entry, and one corrected comment.

## What upstream changed

- **Tiled rendering (beta) now covers Routes, Tracks and Fog of War**, leaving only the Scratch map on the classic full download. Tracks get their own vector tile endpoint, `GET /api/v1/tiles/tracks/:z/:x/:y.mvt`. Under tiles, routes are colored per track and the route-splitting sliders no longer apply.
- **`points` slimming.** New `point_sources` dimension table, a nullable `points.source_id` FK, and a `DataMigrations::BackfillPointDimensionsJob` chain that walks the table in 50k-row batches with a 5s pause between them, then chains a country-id backfill.
- **Per-account geocoding providers.** Photon, Geoapify, Nominatim and LocationIQ are now pickable per user under Settings → Integrations, stored in a new `service_settings` table. Lookups are paced by a new rate limiter, and the Integrations settings page was reorganised into a sidebar.
- **New GiST index on `tracks.original_path`**, built `CONCURRENTLY`.
- Assorted fixes: AirTrail settings no longer crash on an unreachable host, family sharing durations, speed color scale applying to tiled tracks immediately, number/date formatting following the interface language.

## Add-on impact

### Migrations (the restart-loop risk)

`svc-dawarich/run` does `rails db:migrate` and `exit 1` on failure, so a migration that raises is a boot loop. Six new migrations, all checked:

| Migration | Verdict |
|---|---|
| `20260816150000_create_point_dimension_tables` | Safe. Creates `point_sources`, then tries the `ALTER TABLE points ADD COLUMN source_id` five times with a 1s `lock_timeout`. On exhaustion it **logs and returns** rather than raising, deliberately, and hands the column off to `DataMigrations::AddPointDimensionColumnsJob`. Every statement is `IF NOT EXISTS`, so a rerun is safe. |
| `20260816150100_drop_visit_null_partial_index` | Safe. `DROP INDEX CONCURRENTLY ... IF EXISTS`. Fast, but happens while the user is looking at the loading page. |
| `20260816150200_enqueue_point_dimension_backfills` | Safe. Only enqueues. Rescues `StandardError` and logs a manual resume command; re-raises `NameError` only, which would be a broken image rather than a runtime hiccup. |
| `20260818201239_add_gist_index_to_tracks_original_path` | Safe, possibly slow. Sets `lock_timeout = 0`, drops a leftover INVALID index if one exists, then `CREATE INDEX CONCURRENTLY ... USING gist`. `tracks` is orders of magnitude smaller than `points`, so this should be seconds to a couple of minutes, not the multi-minute points index rebuild we warned about in 1.12.2-1. Nothing else writes during `db:migrate`, so `lock_timeout = 0` cannot hang on us. |
| `20260819120000_create_service_settings` | Safe. Plain `create_table` with `if_not_exists`. |
| `20260819120100_seed_geocoding_service_settings_from_env` | Safe. Runs `User.find_each` synchronously, seeding each user's provider row from our `PHOTON_API_HOST` / `GEOAPIFY_API_KEY` env. Per-user failures are rescued and logged inside `Geocoding::SeedFromEnv#create_setting`. With the handful of users this add-on creates, the cost is negligible. |

The backfill itself is the long pole, not the migration. `BackfillPointDimensionsJob` bounds each batch with `lock_timeout 2s` / `statement_timeout 5min`, halves the batch size on a statement timeout down to a 5k floor, retries ten times on lock timeouts, and logs a resume cursor if it gives up. It is idempotent and resumable, so an add-on restart mid-backfill costs one batch. It runs on the `data_migrations` queue, which is second in `sidekiq.yml`'s priority list, so it will win against imports and stats while it runs.

`SKIP_POINT_DIMENSION_BACKFILL=1` exists as an opt-out. **I did not expose it as an add-on option** and want a second opinion on that: it adds permanent config surface for a one-time event, and skipping it leaves history unstamped with no in-app way to start it later. Say the word and I will add it.

### Sidekiq

No new queues. `data_migrations`, `reverse_geocoding` and `tracks` are the queues the new and changed jobs declare, and all three are already in upstream's `config/sidekiq.yml`. `svc-sidekiq/run` passes no `-q`, so it picks them up from that file as before. Nothing to change.

One behaviour change worth knowing: `config/initializers/sidekiq.rb` replaced the old "cap `reverse_geocoding` at 1 worker only when Photon is komoot" rule with an unconditional `limit = max(BACKGROUND_PROCESSING_CONCURRENCY / 3, 1)`. At our default concurrency of 5 that is **1**. For the default add-on setup (komoot Photon) this changes nothing, it was already 1. For someone pointing `photon_api_host` at their own Photon server, bulk geocoding drops from up to 5 workers to 1. `REVERSE_GEOCODING_CONCURRENCY` overrides it. Also not exposed as an option, for the same reason as above.

Our `z_sidekiq_redis_timeout.rb` override is unaffected: upstream's edit is at the bottom of its own initializer and does not touch `config.redis`.

### PostGIS

`Tracks::VectorTileQuery` uses `ST_AsMVT`, `ST_AsMVTGeom`, `ST_TileEnvelope`, `ST_Simplify`, `ST_Transform` and `ST_Intersects`. All present in PostGIS 3.x, and `ST_TileEnvelope` (the newest of them, 3.0) is already exercised by the points tile query we ship in 1.13.0. `postgresql-17-postgis-3` from PGDG covers it.

### Ingress and JavaScript

This is where these releases usually break, and this time it does not.

The new track tile URL is built in `tracks_mvt_layer.js` as the literal `"/api/v1/tiles/tracks/{z}/{x}/{y}.mvt"`, exactly parallel to the points layer. The `sub_filter '"/api/v1/tiles/'` we added in 1.13.0-2 rewrites it, along with the unchanged `startsWith("/api/v1/tiles/")` guard in `map_initializer.js:53` that decides whether to attach the Bearer key. Both sides of that comparison get the prefix, so the guard still matches. I updated the comment above the sub_filter to name `tracks_mvt_layer.js` too, since it now covers three call sites rather than two.

Checked and found harmless:
- No new `Worker` anywhere in the map code, so the injected fetch/XHR patch's blind spot is not newly exposed.
- The only `window.location.origin` use is `map_initializer.js`'s `new URL(url, window.location.origin)` inside `transformRequest`, which is unchanged from 1.13.0 and resolves an already-rewritten path.
- `basemap_fallback.js` ("fill gaps with the default basemap") composes against `TILE_SOURCE_URL`, the absolute `https://tyles.dwri.xyz/...`, not a same-origin path. Nothing for nginx to do, and the feature is off by default.
- `geocoding_settings_controller.js` builds no URLs at all; the "Test my provider" button goes through a normal Rails form, covered by the `action="/` filter.
- `rack_attack.rb` raised the tile limits from 5000/300 to 10000/600 because two tile sources now share the key. A raise, so nothing new can trip behind ingress where every user shares one apparent IP.

### Environment

Diffed `docker/.env.example` against `init-dawarich.sh`. Five new variables, none exposed:

- `VECTOR_TILES_QUERY_TIMEOUT_MS` (default 5000) — raise only if huge date ranges time out under tiled rendering. Skipped; wait until someone hits it.
- `REVERSE_GEOCODING_RPS` — pacing ceiling. Skipped; komoot is pinned to 1/s regardless.
- `REVERSE_GEOCODING_CONCURRENCY` — see the Sidekiq note above. Skipped.
- `SKIP_POINT_DIMENSION_BACKFILL` — see the migration note above. Skipped.
- `NOMINATIM_API_HOST` / `LOCATIONIQ_API_KEY` — the two new providers as instance-wide env. Skipped, because the point of 1.13.1's geocoding work is that they are now pickable in the UI.

That last one interacts with our options in a way worth stating plainly: `Geocoding::Config.for(user)` returns the env config whenever any provider env var is set, and only falls through to the per-user picker when none is. So with `reverse_geocoding: true` in the add-on config we set `PHOTON_API_HOST` (or `GEOAPIFY_API_KEY`) and the add-on options keep winning, with the migration seeding those values into the new UI so it shows what is actually in use. With `reverse_geocoding: false` we set nothing, and a user can now enable geocoding per account from the UI, which was not possible before. Neither is a regression, but the second one means geocoding can now happen without the add-on option being on.

### Not affected

`disable_host_authorization.rb`, `session_store.rb`, `z_devise_persistence.rb` and `action_cable.rb` are untouched by anything in this diff. No changes to auth, session handling or ActionCable upstream. Backup and restore paths are unchanged. No `config/schedule.yml` changes.

## Needs testing on hardware

I cannot reach a Home Assistant instance, so none of the below is verified.

1. **First boot after the upgrade.** Watch the log through `db:migrate`. The GiST index build on `tracks` is the slow step; the loading page is expected. Confirm the app comes up and does not restart.
2. **The backfill.** Look for `[BackfillPointDimensions] stamped N points in A..B (~X% of id range)` lines climbing toward 100%, and `[BackfillPointDimensions] completed at id N` at the end. Watch free disk on `/data` while it runs, since the table grows before it shrinks. If it stops early the log carries a `perform_later` resume command.
3. **The lock-timeout branch.** If `[CreatePointDimensionTables] could not acquire lock` appears, the column was deferred to a job. Check `points.source_id` exists afterwards. This should not happen with nothing else writing during migrate, but it is the untested path.
4. **Tracks and Routes under tiled rendering, through the sidebar.** This is the ingress risk. Turn on Tiled rendering in Map v2 → Settings, then enable Tracks and Routes. Tiles should load; "Could not load map tiles" or 404s on `/api/v1/tiles/tracks/...` in the network tab means the sub_filter did not reach the built asset. Compare against port 3000, which bypasses ingress.
5. **Fog of War under tiled rendering**, same check.
6. **Settings → Integrations.** The page was rebuilt around a sidebar and the old geocoding tab now redirects. Confirm the redirect lands correctly behind ingress, since ingress-prefixed redirects are handled by `proxy_redirect` rather than the JS patch. Confirm the geocoding provider shows the add-on's Photon/Geoapify settings pre-filled.
7. **Reverse geocoding still runs** at all, given the queue is now capped at one worker.

## Proposed changelog entry

Written to publish under your name, so review the voice before merging.

```markdown
## 1.13.1-1

- Upgrade base image to Dawarich [1.13.1](https://github.com/Freika/dawarich/releases/tag/1.13.1). The Tiled rendering beta now draws Tracks, Routes and Fog of War as well, so only the Scratch map still falls back to loading everything up front. It stays off until you switch it on under Map v2 → Settings
- **Slow first boot, then a background job that can run for hours.** Device and importer details move out of the points table into a shared one, which makes a large history noticeably smaller on disk. Existing points are converted in the background after the upgrade: expect high CPU for a while, and the database to grow before it shrinks, so check the drive has room. Your points, tracks, visits and stats are untouched, nothing changes in the app while it runs, and the app boots normally whether or not it finishes
- Each account can now pick its own geocoding provider (Photon, Geoapify, Nominatim or LocationIQ) under Settings → Integrations. With `reverse_geocoding` enabled in the app configuration, those options still win and the picker only shows what is already in use. Reverse geocoding also now uses one background worker instead of up to five, which only slows anything down if you point the app at your own Photon server
- No app config changes required
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Avd7G53AfWq6eqTL8isRJZ)_